### PR TITLE
Update swagger json to Streamr CDN

### DIFF
--- a/assets/data/configuration.json
+++ b/assets/data/configuration.json
@@ -1,5 +1,5 @@
 {
-  "url": "https://gitcdn.link/repo/streamr-dev/engine-and-editor/2c4eec28199f948a6efb84b89f6ef2f8666c1804/docs/swagger.json",
+  "url": "https://cdn.streamr.com/swagger.json",
   "defaultTitle": "API",
   "proxy": "https://cors-anywhere.herokuapp.com/",
   "defaultDarkTheme": false,


### PR DESCRIPTION
gitcdn.link has uptime issues, replacing with our own infra. 