### PR TITLE
[PLATFORM-1248] Swagger URL as an ENV variable 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ jobs:
   - stage: Api-Explorer Build Staging
     env:
     - NODE_ENV=production
+    - PUBLIC_PATH=https://cdn.streamr.com
     script:
     - npm install
     - npm run vendor:icons-bundle
@@ -38,6 +39,7 @@ jobs:
     if: NOT type IN (pull_request)
     env:
     - NODE_ENV=production
+    - PUBLIC_PATH=https://cdn.streamr.com
     script:
     - npm install
     - npm run vendor:icons-bundle

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
   - stage: Api-Explorer Build Staging
     env:
     - NODE_ENV=production
-    - PUBLIC_PATH=https://cdn.streamr.com
+    - PUBLIC_PATH=https://marketplace-staging.streamr.com
     script:
     - npm install
     - npm run vendor:icons-bundle

--- a/assets/scripts/services/configuration.js
+++ b/assets/scripts/services/configuration.js
@@ -5,6 +5,7 @@ import defaultConfiguration from '../../data/configuration'
 // export const configuration = window.OAX.cfg = {
 export const configuration = {
   ...defaultConfiguration,
+  'url': process.env.SWAGGER_PATH,
   // ...(window.OAX.cfg || {}),
   ...{
     components: {

--- a/build/config/dev.env.js
+++ b/build/config/dev.env.js
@@ -2,5 +2,6 @@ var merge = require('webpack-merge')
 var prodEnv = require('./prod.env')
 
 module.exports = merge(prodEnv, {
-  NODE_ENV: '"development"'
+  NODE_ENV: '"development"',
+  SWAGGER_PATH: '"https://cdn.streamr.com/swagger.json"'
 })

--- a/build/config/index.js
+++ b/build/config/index.js
@@ -7,7 +7,7 @@ module.exports = {
     index: path.resolve(__dirname, '../../dist/index.html'),
     assetsRoot: path.resolve(__dirname, '../../dist'),
     assetsSubDirectory: './static',
-    assetsPublicPath: './',
+    assetsPublicPath: `${process.env.PUBLIC_PATH || ''}/`,
     productionSourceMap: false,
     // Gzip off by default as many popular static hosts such as
     // Surge or Netlify already gzip all static assets for you.

--- a/build/config/prod.env.js
+++ b/build/config/prod.env.js
@@ -1,3 +1,4 @@
 module.exports = {
-  NODE_ENV: '"production"'
+  NODE_ENV: '"production"',
+  SWAGGER_PATH: '"https://cdn.streamr.com/swagger.json"'
 }


### PR DESCRIPTION
Process ENV var:
`SWAGGER_PATH`

The base project defines ENV variables in a really weird way. So I'm not sure if the travis builds will be able to override them properly. Give this a test and I can try again if this fails. 

