### PR TITLE
feat: Use CDN:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
   - stage: Api-Explorer Build Staging
     env:
     - NODE_ENV=production
-    - PUBLIC_PATH=https://marketplace-staging.streamr.com
+    - PUBLIC_PATH=https://marketplace-staging.streamr.com/api-explorer
     - SWAGGER_PATH=https://marketplace-staging.streamr.com/swagger.json
     script:
     - npm run vendor:icons-bundle
@@ -36,6 +36,19 @@ jobs:
       secret_access_key:
         secure: lDYOQabCULKF1mDvYguA/mF9rZomlRTe7aTvXgienyjrp/gj8azjAi6Q+Z/UJiKtcDdWxtKGYBhUohbVSjN4VdGSdqhdHqf4yT9cgV0B0l1Yu4BYKSmy8HV+yLJ1NJ5vG9UM7EZd/CiwkjumBylnBjl+apZiMRtQa/XPT0QMO+adRG/W3AcceMLu73ItICUoaIbXy5Ti2MUWPEwf87IMSP/F/S9TFGEW5n3+bK5iT/fmjRHt2+4D7P2bE+zOXlpDmF4or2Q0SfROupbspGwSt2vow0Vxr7oAeyuDjbVvgaMvu9iUugFeGHPepWArnyjk5TZOvoCMqHKDIHPUdKu9OHTFu+CZOBbyXR1r3n71Rn2pPALHDUG58tmD7W9GUQSaCJtbyPgbQAlynyXa76gsut5dlF+LJfqB1ADb4Du6D1ZAk+fPZxbET72POdSAdDh9WqoWVsOPMMs7LxvLI0KoFxSJOdgxSarVx3Dl5R3QUg7yrAer3Z1gcGeIU1FzVbfpLAkY5sKljwr9ssCGvvrtPAoBp6ylmXY9usNNH+0obuwr7WURqgrborG5v/L4rjuihlf3GALVkf7X9qqiMHXJsd9wJ3rxLseAMbz6rhiNQYpDa/S16zwHraNM3OM0jHdNTWGQEgG+qSsuWhTDYuZNfakfHs2e7Pbsqe3Ou/KJ+hk=
       bucket: eu-west-1-stg-streamr-api-explorer
+      local_dir: "$TRAVIS_BUILD_DIR/dist"
+      upload-dir: "${TRAVIS_JOB_ID}/"
+      acl: private
+      region: eu-west-1
+      skip_cleanup: true
+      on:
+        branch: development
+    - provider: s3
+      access_key_id: AKIAI3FGPGMK3EREJJTQ
+      secret_access_key:
+        secure: lDYOQabCULKF1mDvYguA/mF9rZomlRTe7aTvXgienyjrp/gj8azjAi6Q+Z/UJiKtcDdWxtKGYBhUohbVSjN4VdGSdqhdHqf4yT9cgV0B0l1Yu4BYKSmy8HV+yLJ1NJ5vG9UM7EZd/CiwkjumBylnBjl+apZiMRtQa/XPT0QMO+adRG/W3AcceMLu73ItICUoaIbXy5Ti2MUWPEwf87IMSP/F/S9TFGEW5n3+bK5iT/fmjRHt2+4D7P2bE+zOXlpDmF4or2Q0SfROupbspGwSt2vow0Vxr7oAeyuDjbVvgaMvu9iUugFeGHPepWArnyjk5TZOvoCMqHKDIHPUdKu9OHTFu+CZOBbyXR1r3n71Rn2pPALHDUG58tmD7W9GUQSaCJtbyPgbQAlynyXa76gsut5dlF+LJfqB1ADb4Du6D1ZAk+fPZxbET72POdSAdDh9WqoWVsOPMMs7LxvLI0KoFxSJOdgxSarVx3Dl5R3QUg7yrAer3Z1gcGeIU1FzVbfpLAkY5sKljwr9ssCGvvrtPAoBp6ylmXY9usNNH+0obuwr7WURqgrborG5v/L4rjuihlf3GALVkf7X9qqiMHXJsd9wJ3rxLseAMbz6rhiNQYpDa/S16zwHraNM3OM0jHdNTWGQEgG+qSsuWhTDYuZNfakfHs2e7Pbsqe3Ou/KJ+hk=
+      bucket: eu-west-1-stg-streamr-marketplace
+      upload-dir: api-explorer/
       local_dir: "$TRAVIS_BUILD_DIR/dist"
       acl: private
       region: eu-west-1


### PR DESCRIPTION
Api-explorer to behave like other FE apps will fetch the resources via CDN

* Store a version on the explorer in S3 as backup
* Push api-explorer to CDN under https://<cdn>/api-explorer